### PR TITLE
Changed type for invoke method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,34 @@ $container['phpErrorHandler'] = $container['errorHandler'] = function($c) {
 
 $app->run();
 ```
+
+## Additional handlers
+ 
+Custom handlers can be added to execute additional tasks.
+For example, you might want to log the error like so:
+
+```php
+include "vendor/autoload.php";
+
+use Whoops\Handler\Handler;
+use Dopesong\Slim\Error\Whoops as WhoopsError;
+
+$app = new Slim\App();
+$container = $app->getContainer();
+
+$container['phpErrorHandler'] = $container['errorHandler'] = function ($container) {
+    $logger = $container['logger'];
+    $whoopsHandler = new WhoopsError();
+
+    $whoopsHandler->pushHandler(
+        function ($exception) use ($logger) {
+            /** @var \Exception $exception */
+            $logger->error($exception->getMessage(), ['exception' => $exception]);
+            return Handler::DONE;
+        }
+    );
+
+    return $whoopsHandler;
+};
+```
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ include "vendor/autoload.php";
 $app = new Slim\App();
 $container = $app->getContainer();
 
-$container['errorHandler'] = function($c) {
+$container['phpErrorHandler'] = $container['errorHandler'] = function($c) {
     return new WhoopsError($c->get('settings')['displayErrorDetails']);
 };
 

--- a/src/Whoops.php
+++ b/src/Whoops.php
@@ -10,7 +10,6 @@ use Whoops\Handler\JsonResponseHandler;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Exception;
 
 /**
  * Whoops Error Handler
@@ -68,11 +67,11 @@ class Whoops
     /**
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
-     * @param Exception              $exception
+     * @param \Throwable              $throwable
      *
      * @return ResponseInterface
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, Exception $exception)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $throwable)
     {
         $contentType = $this->determineContentType($request);
 
@@ -80,7 +79,7 @@ class Whoops
 
         $output = null;
 
-        $output = $this->whoops->handleException($exception);
+        $output = $this->whoops->handleException($throwable);
 
         $body = $response->getBody();
         $body->write($output);


### PR DESCRIPTION
According to [the php manual for php 7](http://php.net/manual/en/language.errors.php7.php) php has the following error hierarchy:
- Throwable
  - Error
    - AssertionError
    - ParseError
    - TypeError
  - Exception

Which means that as long as we use the `Throwable` interface, we can handle anything in the hierarchy. Unfortunately, the typehint on __invoke prevents us from doing that, so I suggest we remove it.

We could also replace it with a `Throwable` type instead, but that won't sit well with php versions < 7.0

Earlier PHP versions (5.5) will fail with a fatal error in any case without actually making it to the handler (tested on `5.5.38`), so we might as well optimize for newer versions.
